### PR TITLE
For some reason you now have to do this. See link below

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -7,7 +7,7 @@ echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/s
 apt-get -y update
 apt-get -y dist-upgrade
 apt-get install -y tar bash curl libffi-dev git-core make g++ build-essential bison openssl libreadline6 libreadline6-dev zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-0 libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev autoconf libc6-dev ssl-cert subversion
-apt-get install -y openjdk-8-jdk
+apt-get install -y -t jessie-backports openjdk-8-jdk
 
 rm -rf ruby-build /usr/local/ruby
 


### PR DESCRIPTION
http://serverfault.com/questions/830636/cannot-install-openjdk-8-jre-headless-on-debian-jessie